### PR TITLE
feat: home page redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,19 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/docs/overview/introduction',
+        permanent: true,
+      },
+    ]
+  },
   experimental: {
     mdxRs: true,
   },
 }
- 
+
 const withMDX = require('@next/mdx')({
   // ...
   options: {


### PR DESCRIPTION
Created a redirect from the home page ('/') to the docs introduction page ('/docs/overview/introduction')

This will be temporary while the home landing page is being built.  